### PR TITLE
Fix issue with spaces in the read name

### DIFF
--- a/pychopper/hmmer_backend.py
+++ b/pychopper/hmmer_backend.py
@@ -27,7 +27,7 @@ def _parse_hmmscan_tab(lines, reads):
     for x, y in itertools.groupby(res, lambda x: x.Ref):
         buff[x] = list(y)
     for r in reads:
-        yield buff[r.Id]
+        yield buff[r.Id.split()[0]]
 
 
 def find_locations(reads, phmm_file, E, pool, min_batch):


### PR DESCRIPTION
Dorado basecalling does not work because it adds extra information into the read name. see https://github.com/epi2me-labs/pychopper/issues/16